### PR TITLE
fix(ci): pr and pr-close concurrency

### DIFF
--- a/.github/workflows/pr-close.yml
+++ b/.github/workflows/pr-close.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   # PR open and close use the same group, allowing only one at a time
-  group: pr-${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -5,7 +5,7 @@ on:
 
 concurrency:
   # Cancel in progress for PR open and close
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.event.number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
PR open and close should interrupt each other.  Their groups weren't matching.