### PR TITLE
fix: variable not initialized raising an error

### DIFF
--- a/sync/src/module/data_synchronization.py
+++ b/sync/src/module/data_synchronization.py
@@ -137,6 +137,7 @@ def execute_process(base_dir, track_db_conn, track_db_schema, process, oracle_co
     stored_metrics['time_conn_target'] = None
     stored_metrics['rows_target_processed'] = 0
     stored_metrics['time_target_load'] = None
+    stored_metrics['time_conn_source'] = None
     retry=False
     tag_reprocess = ''
     if is_reprocess:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

The delta time for source connection ("time_conn_source") is not initialized (as None) when ETL process begin, so, if an error happens when trying to connect, this variable is not set, causing an error.


Fixes # (86)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit test
- [x] Test scenario


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
